### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Pod/Parser.pm
+++ b/lib/Pod/Parser.pm
@@ -1,5 +1,5 @@
 use v6;
-class Pod::Parser;
+unit class Pod::Parser;
 
 use Pod::Parser::Common;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
