### PR TITLE
Use "\n" for newline on Linux/Unix

### DIFF
--- a/t/01-parse.t
+++ b/t/01-parse.t
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-my $N = chr(13) ~ chr(10);
+my $N = $*KERNEL.name eq "win32" ?? chr(13) ~ chr(10) !! "\n";
 
 my @expected = Array.new(
 	{type => 'text', content => "text before$N$N"},


### PR DESCRIPTION
The current test used effectively "\r\n" as its newline combination when
comparing the parsed output with that expected.  This setting is Windows
specific and this commit makes the tests pass on Linux/Unix systems.
