### PR TITLE
Specify a non-asterisk version in META

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,5 @@
 {
-    "perl"        : "6.*",
+    "perl"        : "6.d",
     "name"        : "Pod::Parser",
     "version"     : "*",
     "description" : "Naive parser for Perl 6 style POD documents",


### PR DESCRIPTION
Having an version with an asterisk fails the ecosystem tests.

See one such failure in https://travis-ci.com/github/Raku/ecosystem/builds/204007135 and https://github.com/Raku/ecosystem/pull/567 for some added context